### PR TITLE
Fix explosion crosshairs

### DIFF
--- a/server.js
+++ b/server.js
@@ -170,7 +170,7 @@ function getNumPlayers() {
 }
 
 function attemptUpgrade(socketID, upgradeName, upgradeIncrement, cost, costIncrement) {
-    if(players[socketID].credits >= cost) {
+    if (players[socketID].credits >= cost) {
         players[socketID][upgradeName] += upgradeIncrement;
         players[socketID].credits -= cost;
         io.to(socketID).emit('updateCredits', players[socketID].credits);

--- a/server.js
+++ b/server.js
@@ -100,6 +100,8 @@ io.on('connect', socket => {
             thisPlayer.reloading = true;
             missileData["id"] = missileId;
             missiles[missileId] = missileData;
+            missiles[missileId].startX = missiles[missileId].x
+            missiles[missileId].startY = missiles[missileId].y
             missiles[missileId].speedX = -1 * Math.cos(missileData.rotation + Math.PI / 2) * players[socket.id].speed;
             missiles[missileId].speedY = -1 * Math.sin(missileData.rotation + Math.PI / 2) * players[socket.id].speed;
             missiles[missileId].dmg = players[socket.id].damage;
@@ -194,10 +196,9 @@ function updateMissiles() {
         Object.keys(missiles).forEach(id => {
             missiles[id].x = missiles[id].x + missiles[id].speedX;
             missiles[id].y = missiles[id].y + missiles[id].speedY;
-            
-            let missileOrigin = [players[missiles[id].playerId].x, players[missiles[id].playerId].y]
-            let travelDist = Math.sqrt(Math.pow(missiles[id].x - missileOrigin[0], 2) + Math.pow(missiles[id].y - missileOrigin[1], 2))
-            let targetDist = Math.sqrt(Math.pow(missiles[id].mouseX - missileOrigin[0], 2) + Math.pow(missiles[id].mouseY - missileOrigin[1], 2))
+
+            let travelDist = Math.sqrt(Math.pow(missiles[id].x - missiles[id].startX, 2) + Math.pow(missiles[id].y - missiles[id].startY, 2))
+            let targetDist = Math.sqrt(Math.pow(missiles[id].mouseX - missiles[id].startX, 2) + Math.pow(missiles[id].mouseY - missiles[id].startY, 2))
             let isAtTarget = missiles[id].x >= missiles[id].mouseX - 10 && missiles[id].x <= missiles[id].mouseX + 10 && missiles[id].y >= missiles[id].mouseY - 10 && missiles[id].y <= missiles[id].mouseY + 10
             if (isAtTarget || travelDist >= targetDist) {
                 // create explosion on missile destroy
@@ -206,7 +207,7 @@ function updateMissiles() {
                 if (travelDist > targetDist && !isAtTarget) {
                     explosionLocation[0] = missiles[id].mouseX
                     // use the target y-location only if it is above the base
-                    if (missiles[id].mouseY <= missileOrigin[1]) {
+                    if (missiles[id].mouseY <= missiles[id].startY) {
                         explosionLocation[1] = missiles[id].mouseY
                     }
                 }


### PR DESCRIPTION
In this PR:

- Fixed a bug where the missile would never be detected inside the target explosion area because its speed was too high or because the target area was too far below the base
- In both cases, the missile would never explode, and it would eventually fly off the screen and never be deleted; the missile's crosshair would also never be removed from the screen
- Now, missiles will always explode even when their speed is very high or their target is below the base

To test:
- If you click below the base near the bottom of the screen, a missile should travel horizontally toward that location and then explode as close as possible to it (without leaving a crosshair behind)
- If you upgrade missile speed a lot and then click anywhere on the screen, the missile should travel toward that location and then explode near it (also without leaving a crosshair behind)