### PR TITLE
Chat game separation

### DIFF
--- a/components/ChatLayout.js
+++ b/components/ChatLayout.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef, createRef } from "react";
 import io from "socket.io-client";
 
 // Styling
@@ -14,6 +14,8 @@ const Chat = () => {
     const [name, setName] = useState("");
     const [message, setMessage] = useState("");
     const [messages, setMessages] = useState([]);
+    const inputArea = createRef();
+    const chatArea = useRef();
     const ENDPOINT = window.location.protocol + '//' + window.location.hostname + ':' + window.location.port
 
     useEffect(() => {
@@ -46,6 +48,22 @@ const Chat = () => {
         socket.on("defaultName", ({ name }) => {
             setName(name);
         });
+
+        function unfocusChat(event) {
+            console.log("UNFOCUS FUNCTION")
+            console.log(chatArea.current)
+            console.log(chatArea.current.contains(event.target))
+            if (chatArea.current && !chatArea.current.contains(event.target)) {
+                // inputArea.current.blur()
+                console.log("TODO")
+            }
+        }
+
+        document.addEventListener("mousedown", unfocusChat)
+
+        return () => {
+            document.removeEventListener("mousedown", unfocusChat)
+        }
     }, []);
 
     const sendMessage = (event) => {
@@ -59,9 +77,9 @@ const Chat = () => {
 
     return (
         <div className="outerContainer">
-            <div className="container">
+            <div className="container" ref={chatArea}>
                 <Messages messages={messages} name={name} />
-                <Input message={message} setMessage={setMessage} sendMessage={sendMessage} />
+                <Input ref={inputArea} focus={focus} message={message} setMessage={setMessage} sendMessage={sendMessage} />
             </div>
         </div>
     );

--- a/components/ChatLayout.js
+++ b/components/ChatLayout.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, createRef } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import io from "socket.io-client";
 
 // Styling
@@ -14,7 +14,7 @@ const Chat = () => {
     const [name, setName] = useState("");
     const [message, setMessage] = useState("");
     const [messages, setMessages] = useState([]);
-    const inputArea = createRef();
+    const [focus, setFocus] = useState("");
     const chatArea = useRef();
     const ENDPOINT = window.location.protocol + '//' + window.location.hostname + ':' + window.location.port
 
@@ -49,20 +49,16 @@ const Chat = () => {
             setName(name);
         });
 
-        function unfocusChat(event) {
-            console.log("UNFOCUS FUNCTION")
-            console.log(chatArea.current)
-            console.log(chatArea.current.contains(event.target))
-            if (chatArea.current && !chatArea.current.contains(event.target)) {
-                // inputArea.current.blur()
-                console.log("TODO")
+        function updateFocus(event) {
+            if (chatArea.current) {
+                setFocus(chatArea.current.contains(event.target))
             }
         }
 
-        document.addEventListener("mousedown", unfocusChat)
+        document.addEventListener("mousedown", updateFocus)
 
         return () => {
-            document.removeEventListener("mousedown", unfocusChat)
+            document.removeEventListener("mousedown", updateFocus)
         }
     }, []);
 
@@ -77,9 +73,9 @@ const Chat = () => {
 
     return (
         <div className="outerContainer">
-            <div className="container" ref={chatArea}>
+            <div className="container" ref={chatArea} id="test">
                 <Messages messages={messages} name={name} />
-                <Input ref={inputArea} focus={focus} message={message} setMessage={setMessage} sendMessage={sendMessage} />
+                <Input focus={focus} message={message} setMessage={setMessage} sendMessage={sendMessage} />
             </div>
         </div>
     );

--- a/components/ChatLayout.js
+++ b/components/ChatLayout.js
@@ -73,7 +73,7 @@ const Chat = () => {
 
     return (
         <div className="outerContainer">
-            <div className="container" ref={chatArea} id="test">
+            <div className="container" ref={chatArea}>
                 <Messages messages={messages} name={name} />
                 <Input focus={focus} message={message} setMessage={setMessage} sendMessage={sendMessage} />
             </div>

--- a/components/Input.js
+++ b/components/Input.js
@@ -7,6 +7,7 @@ const Input = (props) => {
     return (
         <form className="form">
             <input
+                ref={props.inputArea}
                 className="input"
                 type="text"
                 placeholder="Type a message..."

--- a/components/Input.js
+++ b/components/Input.js
@@ -5,9 +5,15 @@ import "./Input.scss";
 // event object contains info about details of the event
 const Input = (props) => {
     const input = useRef()
+    const sendButton = useRef()
     
-    if (!props.focus && input.current) {
-        input.current.blur()
+    if (!props.focus) {
+        if (input.current) {
+            input.current.blur()
+        }
+        if (sendButton.current) {
+            sendButton.current.blur()
+        }
     }
 
     return (
@@ -21,7 +27,7 @@ const Input = (props) => {
                 onChange={(event) => props.setMessage(event.target.value)}
                 onKeyPress={(event) => event.key === 'Enter' ? props.sendMessage(event) : null}
             />
-            <button className="sendButton" onClick={(event) => props.sendMessage(event)}>Send</button>
+            <button ref={sendButton} className="sendButton" onClick={(event) => props.sendMessage(event)}>Send</button>
         </form>
     );
 };

--- a/components/Input.js
+++ b/components/Input.js
@@ -1,13 +1,19 @@
-import React from 'react';
+import React, { useRef } from 'react';
 
 import "./Input.scss";
 
 // event object contains info about details of the event
 const Input = (props) => {
+    const input = useRef()
+    
+    if (!props.focus && input.current) {
+        input.current.blur()
+    }
+
     return (
         <form className="form">
             <input
-                ref={props.inputArea}
+                ref={input}
                 className="input"
                 type="text"
                 placeholder="Type a message..."

--- a/public/static/gameScene.js
+++ b/public/static/gameScene.js
@@ -624,10 +624,6 @@ class GameScene extends Phaser.Scene {
         }
     }
 
-    isInGameWindow(pointer) {
-        return pointer.x >= 0 && pointer.x <= 1280 && pointer.y >= 0 && pointer.y <= 720
-    }
-
     //Helper add functions
     addTankBody(self, playerInfo) {
         return self.add

--- a/public/static/gameScene.js
+++ b/public/static/gameScene.js
@@ -48,7 +48,10 @@ class GameScene extends Phaser.Scene {
 
         this.socket.emit('requestInitialize');
 
+        this.pointerInGame = true
         this.game.canvas.oncontextmenu = (e) => e.preventDefault()
+        this.game.canvas.onmouseover = (e) => this.pointerInGame = true
+        this.game.canvas.onmouseout = (e) => this.pointerInGame = false
 
         //Load background
         this.add.image(640, 360, "background").setScale(1);
@@ -454,7 +457,7 @@ class GameScene extends Phaser.Scene {
             }
 
             if (pointer.isDown) {
-                this.focus = this.isInGameWindow(pointer)
+                this.focus = this.pointerInGame
             }
 
             //Shot handling
@@ -596,7 +599,7 @@ class GameScene extends Phaser.Scene {
     //Function for UI tray movement
     moveUI(pointer, UICutoffY) {
         if (!this.UITweening) {
-            if (pointer.y >= UICutoffY) {
+            if (pointer.y >= UICutoffY || !this.pointerInGame) {
                 if (this.UIOut) {
                     this.tweens.add({
                         targets: this.shopUI.getChildren(),
@@ -608,7 +611,7 @@ class GameScene extends Phaser.Scene {
                     this.UIOut = false;
                 }
             } else {
-                if (!this.UIOut) {
+                if (!this.UIOut && this.pointerInGame) {
                     this.tweens.add({
                         targets: this.shopUI.getChildren(),
                         y: "+=120",
@@ -620,10 +623,6 @@ class GameScene extends Phaser.Scene {
                 }
             }
         }
-    }
-
-    isInGameWindow(pointer) {
-        return pointer.x >= 0 && pointer.x <= 1280 && pointer.y >= 0 && pointer.y <= 720
     }
 
     //Helper add functions

--- a/public/static/gameScene.js
+++ b/public/static/gameScene.js
@@ -49,7 +49,6 @@ class GameScene extends Phaser.Scene {
         this.socket.emit('requestInitialize');
 
         this.pointerInGame = true
-        this.game.canvas.oncontextmenu = (e) => e.preventDefault()
         this.game.canvas.onmouseover = (e) => this.pointerInGame = true
         this.game.canvas.onmouseout = (e) => this.pointerInGame = false
 

--- a/public/static/gameScene.js
+++ b/public/static/gameScene.js
@@ -624,6 +624,10 @@ class GameScene extends Phaser.Scene {
         }
     }
 
+    isInGameWindow(pointer) {
+        return pointer.x >= 0 && pointer.x <= 1280 && pointer.y >= 0 && pointer.y <= 720
+    }
+
     //Helper add functions
     addTankBody(self, playerInfo) {
         return self.add

--- a/public/static/gameScene.js
+++ b/public/static/gameScene.js
@@ -1,4 +1,4 @@
-import { angle } from '/static/gameCalculations.js' 
+import { angle } from '/static/gameCalculations.js'
 
 class GameScene extends Phaser.Scene {
     constructor() {
@@ -111,6 +111,7 @@ class GameScene extends Phaser.Scene {
         })
 
         this.makeUI(this);
+        this.focus = true;
 
         //Game variables
         this.shot = false;
@@ -120,11 +121,11 @@ class GameScene extends Phaser.Scene {
         this.UITweening = false;
         this.noMissilesLeft = false;
         this.maxMissilesClientCopy = -1;
-      
+
         this.specialAttackClientCopy = "none";
         this.specialAttackActive = false;
         this.specialAttackKey = this.input.keyboard.addKey('Q');
-      
+
         this.created = true;
 
         //Initializing server-handled objects
@@ -378,8 +379,8 @@ class GameScene extends Phaser.Scene {
                     }
                 });
             }
-            
-            
+
+
         })
         this.socket.on("updateRound", (round) => {
             this.roundText.setText(`${round}`);
@@ -444,15 +445,19 @@ class GameScene extends Phaser.Scene {
             //make the UI tray come out and go back in
             this.moveUI(pointer, UICutoffY);
 
-
             //Special attack activate
             if (this.specialAttackKey.isDown && !this.specialAttackActive && this.specialAttackClientCopy != "none") {
                 this.specialAttackActive = true;
                 this.specialAttackHolder.setTint(0xff0000);
             }
 
+            if (pointer.isDown) {
+                this.focus = this.isInGameWindow(pointer)
+            }
+
             //Shot handling
             if (
+                this.focus &&
                 !this.shot &&
                 pointer.isDown &&
                 pointer.y >= UICutoffY &&
@@ -462,7 +467,7 @@ class GameScene extends Phaser.Scene {
                 this.ship.play("fire");
                 this.shot = true;
 
-                if (this.specialAttackActive){
+                if (this.specialAttackActive) {
                     switch (this.specialAttackClientCopy) {
                         case "none":
                             this.specialAttackActive = false;
@@ -471,8 +476,7 @@ class GameScene extends Phaser.Scene {
                     }
                 }
 
-                if (!this.specialAttackActive)
-                {
+                if (!this.specialAttackActive) {
                     this.socket.emit("missileShot", {
                         x: this.ship.x,
                         y: this.ship.y,
@@ -481,7 +485,7 @@ class GameScene extends Phaser.Scene {
                         rotation: this.ship.rotation,
                     });
                 }
-                
+                this.focus = true
             }
 
             if (!pointer.isDown) {
@@ -491,6 +495,9 @@ class GameScene extends Phaser.Scene {
             let keyb = this.input.keyboard;
 
             keyb.addListener('keydown', event => {
+                if (!this.focus) {
+                    return
+                }
                 if (event.keyCode === 192) {
                     this.socket.emit("enterDebug");
                 }
@@ -579,7 +586,7 @@ class GameScene extends Phaser.Scene {
                 }
             })
 
-            if(this.key && !this.key.isDown) {
+            if (this.key && !this.key.isDown) {
                 this.keypressed = false;
             }
         }
@@ -614,10 +621,14 @@ class GameScene extends Phaser.Scene {
         }
     }
 
+    isInGameWindow(pointer) {
+        return pointer.x >= 0 && pointer.x <= 1280 && pointer.y >= 0 && pointer.y <= 720
+    }
+
     //Helper add functions
     addTankBody(self, playerInfo) {
         return self.add
-            .sprite(playerInfo.x, playerInfo.y, "tankbody" + (1+Math.round((playerInfo.x-160)/320.0)))
+            .sprite(playerInfo.x, playerInfo.y, "tankbody" + (1 + Math.round((playerInfo.x - 160) / 320.0)))
             .setScale(0.5)
             .setDepth(25);
     }
@@ -634,15 +645,15 @@ class GameScene extends Phaser.Scene {
 
     updateSpecialAttackIcon(self, somePlayer, newAttackName, color) {
         if (somePlayer.specialAttackIcon != undefined) { somePlayer.specialAttackIcon.destroy(); }
-        if (newAttackName == "none") { 
+        if (newAttackName == "none") {
             if (self === somePlayer) {
                 self.specialAttackHolder.setTint(0xffffff);
             }
-            return; 
+            return;
         }
 
         somePlayer.specialAttackIcon = self.add.sprite(somePlayer.specialAttackHolder.x, somePlayer.specialAttackHolder.y, newAttackName)
-            .setDisplaySize(24,24).setDepth(101).setTint(color);
+            .setDisplaySize(24, 24).setDepth(101).setTint(color);
     }
 
     addPlayer(self, playerInfo) {
@@ -705,7 +716,7 @@ class GameScene extends Phaser.Scene {
     }
 
     displayLaser(self, center, dir, rot) {
-        let tempLaser = self.add.sprite(center.x + 670*dir.x , center.y + 670*dir.y , 'laser').setDisplaySize(100,1280).setDepth(5);
+        let tempLaser = self.add.sprite(center.x + 670 * dir.x, center.y + 670 * dir.y, 'laser').setDisplaySize(100, 1280).setDepth(5);
         tempLaser.play('laserFlux');
         tempLaser.rotation = rot;
         tempLaser.alpha = 1;
@@ -789,15 +800,15 @@ class GameScene extends Phaser.Scene {
     makeUIHalfButtonHelper(self, name, text, consumableType) {
         let xpos = self.shopUIButtonPlacerX;
         let ypos = self.shopUIButtonPlacerY;
-        if (ypos > -80) { 
-            self.shopUIButtonPlacerY = -85; 
+        if (ypos > -80) {
+            self.shopUIButtonPlacerY = -85;
             self.shopUIButtonPlacerX += 130;
         }
         else {
             self.shopUIButtonPlacerY += 65;
         }
 
-        self[name + 'Text'] = self.add.text(xpos - 55, ypos - 32, text, {fontSize: '16px'}).setDepth(102).setTint(0x202020);
+        self[name + 'Text'] = self.add.text(xpos - 55, ypos - 32, text, { fontSize: '16px' }).setDepth(102).setTint(0x202020);
         self[name] = self.add.image(xpos, ypos - 19, 'halfbutton').setDepth(101).setScale(1.25).setTint(0xcfcfcf)
             .setInteractive();
         self.makeButtonClickBehavior(self, self[name], () => {

--- a/public/static/gameScene.js
+++ b/public/static/gameScene.js
@@ -48,6 +48,8 @@ class GameScene extends Phaser.Scene {
 
         this.socket.emit('requestInitialize');
 
+        this.game.canvas.oncontextmenu = (e) => e.preventDefault()
+
         //Load background
         this.add.image(640, 360, "background").setScale(1);
         //this.add.image(640, 360, "stars").setScale(4);
@@ -485,7 +487,6 @@ class GameScene extends Phaser.Scene {
                         rotation: this.ship.rotation,
                     });
                 }
-                this.focus = true
             }
 
             if (!pointer.isDown) {

--- a/public/static/lobbyScene.js
+++ b/public/static/lobbyScene.js
@@ -15,6 +15,7 @@ class LobbyScene extends Phaser.Scene {
     }
 
     create() {
+        this.game.canvas.oncontextmenu = (e) => e.preventDefault()
         this.add.image(640, 360, 'background').setScale(5);
         this.add.image(640, 360, 'stars').setScale(4);
 

--- a/server.js
+++ b/server.js
@@ -254,6 +254,7 @@ io.on('connect', socket => {
             io.to(socket.id).emit('cometSpeedChange', cometSpeed);
         })
         socket.on('changeRound', () => {
+            round++;
             io.emit('updateRound', round);
             increaseDifficulty();
         })

--- a/server.js
+++ b/server.js
@@ -74,9 +74,9 @@ io.on('connect', socket => {
         if (gameState == 'lobby') {
             io.emit('initUsers', users);
         } else if (gameState == 'game') {
-            setTimeout(() => {socket.emit('inProgress')}, 500);
+            setTimeout(() => { socket.emit('inProgress') }, 500);
         } else {
-            setTimeout(() => {socket.emit('gameFinished')}, 500);
+            setTimeout(() => { socket.emit('gameFinished') }, 500);
         }
 
         socket.on('joinInProgress', () => {
@@ -85,7 +85,7 @@ io.on('connect', socket => {
         })
 
         socket.on('startGame', () => {
-            if(users[socket.id] == 'player') {
+            if (users[socket.id] == 'player') {
                 gameState = 'game';
                 io.emit('switchStart');
             }


### PR DESCRIPTION
Closes #86 

In this PR:

- Fixed the issue where clicking the chat area would register the command to shoot in the game
- Fixed the issue where typing in the chat area would issue game commands and vice versa
- Removed the default pop-up window when right-clicking inside the game
- The shop menu's UI now retracts when the player's mouse leaves the game area

To test:

- When you click the chat input region, you should no longer shoot a missile in the game
- When you click the chat input region and then click the game, the chat input region should become unfocused and you should no longer be typing into the chat
- When you click the game and then click the chat, you should no longer be able to press ` to enter debug mode
- When you enter debug mode in the game and then click on the chat, pressing 0-9, -, or + shouldn't have any affect on the game
- When you right-click inside the game, no pop-up should appear (right click still issues a shoot command like before, but we could change this later if we want)
- When you hover over the shop menu with your mouse and then move it outside the game window, the shop menu should immediately retract