### PR TITLE
Game reset on empty

### DIFF
--- a/public/static/gameScene.js
+++ b/public/static/gameScene.js
@@ -419,6 +419,9 @@ class GameScene extends Phaser.Scene {
                 this.healthText.setText(`${health}`);
             }
         })
+        this.socket.on('reload', () => {
+            location.reload();
+        })
         this.socket.on('debug', data => {
             this.debug = true;
             this.debugMode = -1;

--- a/public/static/lobbyScene.js
+++ b/public/static/lobbyScene.js
@@ -86,6 +86,13 @@ class LobbyScene extends Phaser.Scene {
             location.reload();
         })
 
+        this.socket.on('clearLobby', () => {
+            this.inProgress = false;
+            if(this.progressText) {
+                this.progressText.destroy();
+            }
+        })
+
         this.socket.on('disconnect', userId => {
             console.log(this.userTexts)
             if (this.userTexts[userId] != undefined) {

--- a/server.js
+++ b/server.js
@@ -303,6 +303,11 @@ io.on('connect', socket => {
             }
             delete users[socket.id];
             io.emit('disconnect', socket.id);
+            if(Object.keys(players).length == 0) {
+                clearGame();
+                io.emit('reload');
+                gameState = 'lobby';
+            }
         })
     } else {
 

--- a/server.js
+++ b/server.js
@@ -306,6 +306,7 @@ io.on('connect', socket => {
             if(Object.keys(players).length == 0) {
                 clearGame();
                 io.emit('reload');
+                io.emit('clearLobby');
                 gameState = 'lobby';
             }
         })


### PR DESCRIPTION
In this PR:

- If all players leave during a game, the game state is returned to lobby and all comets/missiles/game variables are reset
- If a spectator was spectating the game, they are forcefully returned to the lobby

To test:

- Join as a single player, refresh and you shouldn't see the 'in progress' text and pressing start game should bring you into a new game instead of the previous
- Join as a single player and a spectator, when player leaves the spectator should be forcefully reloaded